### PR TITLE
Fix catching user's initial config state

### DIFF
--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,6 +1,0 @@
-{
-    "workspace.checkThirdParty": false,
-    "diagnostics.disable": [
-        "inject-field"
-    ]
-}

--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,0 +1,6 @@
+{
+    "workspace.checkThirdParty": false,
+    "diagnostics.disable": [
+        "inject-field"
+    ]
+}

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -12,7 +12,6 @@ local prio = require('hop.priority')
 ---@field hl_ns number
 ---@field dim_ns number
 ---@field diag_ns table
----@field cursorline boolean
 
 local M = {}
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -91,9 +91,6 @@ local function create_hint_state(opts)
   -- backup namespaces of diagnostic
   hint_state.diag_ns = vim.diagnostic.get_namespaces()
 
-  -- Store users cursorline state
-  hint_state.cursorline = vim.wo.cursorline
-
   return hint_state
 end
 
@@ -185,12 +182,6 @@ local function add_virt_cur(ns)
   local cur_offset = cur_info[4]
   local virt_col = cur_info[5] - 1
   local cur_line = vim.api.nvim_get_current_line()
-
-  -- toggle cursorline off if currently set
-  local cursorline_info = vim.wo.cursorline
-  if cursorline_info == true then
-    vim.wo.cursorline = false
-  end
 
   -- first check to see if cursor is in a tab char or past end of line or in empty line
   if cur_offset ~= 0 or #cur_line == cur_col then
@@ -442,11 +433,6 @@ end
 function M.quit(hint_state)
   clear_namespace(hint_state.buf_list, hint_state.hl_ns)
   clear_namespace(hint_state.buf_list, hint_state.dim_ns)
-
-  -- Restore users cursorline setting
-  if hint_state.cursorline == true then
-    vim.wo.cursorline = true
-  end
 
   for _, buf in ipairs(hint_state.buf_list) do
     -- sometimes, buffers might be unloaded; that’s the case with floats for instance (we can invoke Hop from them but

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -320,23 +320,25 @@ function M.move_cursor_to(w, line, column, opts)
   vim.api.nvim_win_set_cursor(w, { line, column })
 end
 
-function M.hint_with(jump_target_gtr, hs, opts)
-  M.hint_with_callback(jump_target_gtr, hs, opts, function(jt)
+function M.hint_with(jump_target_gtr, opts)
+  M.hint_with_callback(jump_target_gtr, opts, function(jt)
     M.move_cursor_to(jt.window, jt.line + 1, jt.column - 1, opts)
   end)
 end
 
 ---@param jump_target_gtr function
----@param hs HintState
 ---@param opts Options
 ---@param callback function
-function M.hint_with_callback(jump_target_gtr, hs, opts, callback)
+function M.hint_with_callback(jump_target_gtr, opts, callback)
   local hint = require('hop.hint')
 
   if not M.initialized then
     vim.notify('Hop is not initialized; please call the setup function', 4)
     return
   end
+
+  -- create hint state
+  local hs = create_hint_state(opts)
 
   -- create jump targets
   local generated = jump_target_gtr(opts)
@@ -361,7 +363,6 @@ function M.hint_with_callback(jump_target_gtr, hs, opts, callback)
 
     clear_namespace(hs.buf_list, hs.hl_ns)
     clear_namespace(hs.buf_list, hs.dim_ns)
-    M.quit(hs)
     return
   end
 
@@ -464,11 +465,10 @@ function M.hint_words(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_word_start()), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_word_start()), opts)
 end
 
 function M.hint_camel_case(opts)
@@ -487,7 +487,6 @@ function M.hint_patterns(opts, pattern)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   -- The pattern to search is either retrieved from the (optional) argument
   -- or directly from user input.
@@ -511,14 +510,13 @@ function M.hint_patterns(opts, pattern)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_case_searching(pat, false, opts)), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_case_searching(pat, false, opts)), opts)
 end
 
 function M.hint_char1(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local c = M.get_input_pattern('Hop 1 char: ', 1)
   if not c then
@@ -527,14 +525,13 @@ function M.hint_char1(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_case_searching(c, true, opts)), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_case_searching(c, true, opts)), opts)
 end
 
 function M.hint_char2(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local c = M.get_input_pattern('Hop 2 char: ', 2)
   if not c then
@@ -543,18 +540,17 @@ function M.hint_char2(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_case_searching(c, true, opts)), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_case_searching(c, true, opts)), opts)
 end
 
 function M.hint_lines(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.by_line_start()), hs, opts)
+  M.hint_with(generator(jump_target.by_line_start()), opts)
 end
 
 function M.hint_vertical(opts)
@@ -562,35 +558,32 @@ function M.hint_vertical(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
   -- only makes sense as end position given movement goal.
   opts.hint_position = hint.HintPosition.END
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_vertical()), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_vertical()), opts)
 end
 
 function M.hint_lines_skip_whitespace(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_line_start_skip_whitespace()), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_line_start_skip_whitespace()), opts)
 end
 
 function M.hint_anywhere(opts)
   local jump_target = require('hop.jump_target')
 
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local generator = getGenerator(jump_target, opts)
 
-  M.hint_with(generator(jump_target.regex_by_anywhere()), hs, opts)
+  M.hint_with(generator(jump_target.regex_by_anywhere()), opts)
 end
 
 -- Setup user settings.
@@ -628,7 +621,6 @@ end
 ---@param opts Options
 M.yank_char1 = function(opts)
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
   if opts.multi_windows then
     opts.multi_windows = false
     vim.notify('Cannot use yank across multiple windows', vim.log.levels.WARN)
@@ -649,7 +641,7 @@ M.yank_char1 = function(opts)
       return
     end
 
-    M.hint_with_callback(generator(jump_target.regex_by_case_searching(c, true, opts)), hs, opts, function(jt)
+    M.hint_with_callback(generator(jump_target.regex_by_case_searching(c, true, opts)), opts, function(jt)
       targets[key] = jt
     end)
   end
@@ -670,7 +662,6 @@ end
 
 M.paste_char1 = function(opts)
   opts = override_opts(opts)
-  local hs = create_hint_state(opts)
 
   local jump_target = require('hop.jump_target')
   local generator = getGenerator(jump_target, opts)
@@ -680,7 +671,7 @@ M.paste_char1 = function(opts)
     return
   end
 
-  M.hint_with_callback(generator(jump_target.regex_by_case_searching(c, true, opts)), hs, opts, function(jt)
+  M.hint_with_callback(generator(jump_target.regex_by_case_searching(c, true, opts)), opts, function(jt)
     local target = jt
 
     if target == nil then


### PR DESCRIPTION
Hint state was taken out one layer upwards to main interfaces in order to fix hop pattern as it adds virtual cursor which corrupts user settings. Because of that, hint state has to be saved before that happens.

This is a direct follow up to #148. This rewrite should solve this issue entirely for all cases.