### PR TITLE
fix:change windows in multi windows mode only it's necessery

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -77,7 +77,7 @@ local function create_hint_state(opts)
   hint_state.all_ctxs = window.get_window_context(opts)
   hint_state.buf_list = {}
   for _, bctx in ipairs(hint_state.all_ctxs) do
-    hint_state.buf_list[#hint_state.buf_list + 1] = bctx.buffer_handle
+    hint_state.buf_list[#hint_state.buf_list + 1] = bctx.buf_handle
     for _, wctx in ipairs(bctx.contexts) do
       window.clip_window_context(wctx, opts.direction)
     end
@@ -161,11 +161,11 @@ local function apply_dimming(hint_state, opts)
     for _, wctx in ipairs(bctx.contexts) do
       window.clip_window_context(wctx, opts.direction)
       -- dim everything out, add the virtual cursor and hide diagnostics
-      set_unmatched_lines(bctx.buffer_handle, hint_state.dim_ns, wctx, opts)
+      set_unmatched_lines(bctx.buf_handle, hint_state.dim_ns, wctx, opts)
     end
 
     for ns in pairs(hint_state.diag_ns) do
-      vim.diagnostic.show(ns, bctx.buffer_handle, nil, { virtual_text = false })
+      vim.diagnostic.show(ns, bctx.buf_handle, nil, { virtual_text = false })
     end
   end
 end

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -236,17 +236,17 @@ function M.jump_targets_by_scanning_lines(regex)
     -- Iterate all buffers
     for _, bctx in ipairs(all_ctxs) do
       -- Iterate all windows of a same buffer
-      Context.buf_handle = bctx.buffer_handle
+      Context.buf_handle = bctx.buf_handle
       for _, wctx in ipairs(bctx.contexts) do
         window.clip_window_context(wctx, opts.direction)
 
-        Context.win_handle = wctx.hwin
+        Context.win_handle = wctx.win_handle
         Context.fcol = wctx.fcol
         Context.col_offset = wctx.col_offset
         Context.win_width = wctx.win_width
         Context.cursor_pos = wctx.cursor_pos
         -- Get all lines' context
-        local lines = window.get_lines_context(bctx.buffer_handle, wctx)
+        local lines = window.get_lines_context(bctx.buf_handle, wctx)
         -- in the case of a direction, we want to treat the first or last line (according to the direction) differently
         if opts.direction == hint.HintDirection.AFTER_CURSOR then
           -- the first line is to be checked first

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -1,7 +1,7 @@
 local hint = require('hop.hint')
 
 ---@class WindowContext
----@field hwin number
+---@field win_handle number
 ---@field cursor_pos number[]
 ---@field top_line number
 ---@field bot_line number
@@ -10,7 +10,7 @@ local hint = require('hop.hint')
 ---@field col_offset number
 
 ---@class Context
----@field buffer_handle number
+---@field buf_handle number
 ---@field contexts WindowContext[]
 
 ---@class LineContext
@@ -35,7 +35,7 @@ local function window_context(win_handle, buf_handle)
   local fcol = vim.fn.strdisplaywidth(cursor_line:sub(1, cursor_pos[2])) - win_view.leftcol
 
   return {
-    hwin = win_handle,
+    win_handle = win_handle,
     cursor_pos = cursor_pos,
     top_line = win_info.topline - 1,
     bot_line = win_info.botline,
@@ -57,7 +57,7 @@ function M.get_window_context(opts)
   local cur_hbuf = vim.api.nvim_win_get_buf(cur_hwin)
 
   contexts[1] = {
-    buffer_handle = cur_hbuf,
+    buf_handle = cur_hbuf,
     contexts = { window_context(cur_hwin, cur_hbuf) },
   }
 
@@ -73,7 +73,7 @@ function M.get_window_context(opts)
       -- skips current window and excluded filetypes
       if not (w == cur_hwin or vim.tbl_contains(opts.excluded_filetypes, vim.bo[b].filetype)) then
         contexts[#contexts + 1] = {
-          buffer_handle = b,
+          buf_handle = b,
           contexts = { window_context(w, b) },
         }
       end
@@ -93,7 +93,7 @@ function M.get_lines_context(buf_handle, context)
 
   local lnr = context.top_line
   while lnr < context.bot_line do -- top_line is inclusive and bot_line is exclusive
-    local fold_end = vim.api.nvim_win_call(context.hwin, function()
+    local fold_end = vim.api.nvim_win_call(context.win_handle, function()
       return vim.fn.foldclosedend(lnr + 1) -- `foldclosedend()` use 1-based line number
     end)
     if fold_end == -1 then -- line isn't folded

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -23,9 +23,8 @@ local M = {}
 ---@param win_handle number
 ---@return WindowContext
 local function window_context(win_handle, buf_handle)
-  vim.api.nvim_set_current_win(win_handle)
   local win_info = vim.fn.getwininfo(win_handle)[1]
-  local win_view = vim.fn.winsaveview()
+  local win_view = vim.api.nvim_win_call(win_handle, vim.fn.winsaveview)
   local cursor_pos = vim.api.nvim_win_get_cursor(win_handle)
 
   local win_width = nil


### PR DESCRIPTION
This PR is mainly to avoid changing window cursor when get window context.
For multi-windows, `nvim_set_current_win` may change the focus window when canceling or failing jump.

And the other commit is to rename to `buf_handle` and `win_handle` for `buffer context` and `window context`, to be consistent with JumpContext. If it's not neccessary, we can drop the commit :).
