### PR TITLE
feat: support virtualedit

### DIFF
--- a/lua/hop-treesitter/treesitter.lua
+++ b/lua/hop-treesitter/treesitter.lua
@@ -48,7 +48,12 @@ T.parse = function(ignore_injections)
 
     local len = #locations.jump_targets + 1
     -- Increment column to convert it to 1-index
-    locations.jump_targets[len] = { buffer = 0, cursor = { row = row + 1, col = col }, length = 0, window = 0 }
+    locations.jump_targets[len] = {
+      window = 0,
+      buffer = 0,
+      cursor = { row = row + 1, col = col, off = 0 },
+      length = 0,
+    }
     locations.indirect_jump_targets[len] = { index = len, score = len }
   end
 

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -183,6 +183,7 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
     api.nvim_buf_set_extmark(hint.jump_target.buffer, hl_ns, row, col, {
       virt_text = virt_text,
       virt_text_pos = opts.hint_type,
+      virt_text_win_col = hint.jump_target.cursor.virt,
       hl_mode = 'combine',
       priority = M.HintPriority.HINT,
     })

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -222,7 +222,9 @@ function M.move_cursor_to(jt, opts)
   --local cursor = api.nvim_win_get_cursor(0)
   --api.nvim_buf_set_mark(jt.buffer, "'", cursor[1], cursor[2], {})
   vim.cmd("normal! m'")
-  api.nvim_win_set_cursor(jt.window, { jt.cursor.row, jt.cursor.col })
+  -- Note that nvim_win_set_cursor() only supports virtualedit=all
+  -- Must set cursor with setpos() that supports virtualedit=insert/block
+  vim.fn.setpos('.', { jt.buffer, jt.cursor.row, jt.cursor.col + 1, jt.cursor.off })
 end
 
 ---@param jump_target_gtr Generator

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -4,22 +4,27 @@
 ---@alias WindowCell integer 0-based displayed cell column at window; often computed via `strdisplaywidth()`
 ---@alias WindowChar integer 0-based character index at string
 -- For multi-byte character, there may be WindowCol ~= WindowCell ~= WindowChar like below showed
--- LineString:   a #### b     => '##' is a 4-bytes character takes 2-cells
--- WindowCol     0 1234 5
+-- ```
+-- LineString:   a #### b     => '####' is a 4-bytes character takes 2-cells
+-- WindowCol:    0 1234 5
 -- WindowCell:   0 1 2  3
 -- WindowChar:   0 1    2
+-- ```
 --
 -- Infos for some neovim api:
--- * 1-based line, 0-based column: nvim_win_get_cursor, nvim_win_set_cursor
--- * 0-based line, end-exclusive: nvim_buf_get_lines
--- * 0-based line, end-inclusive; 0-based column, end-exclusive: nvim_buf_set_extmark
--- * 1-based line: foldclosedend
--- * 0-based character index: charidx, strcharpart
--- * 0-based byte index: byteidx, strpart
+-- * 1-based line, 0-based column: nvim_win_get_cursor(), nvim_win_set_cursor()
+-- * 1-based line, 1-based column: getcurpos(), setpos()
+-- * 0-based line, end-exclusive: nvim_buf_get_lines()
+-- * 0-based line, end-inclusive; 0-based column, end-exclusive: nvim_buf_set_extmark()
+-- * 1-based line: foldclosedend()
+-- * 0-based character index: charidx(), strcharpart()
+-- * 0-based byte index: byteidx(), strpart()
 
----@class CursorPos
+---@class Cursor Cursor position and display information
 ---@field row WindowRow
 ---@field col WindowCol
+---@field off WindowCell Jump to blank cell when 'virtualedit' is enabled
+---@field virt WindowCell|nil The cursor cell column displayed relative to the WindowContext.win_offset
 
 ---@alias LineRange WindowRow[] Line range with [top-inclusive, bottom-inclusive]
 ---@alias ColumnRange WindowCol[] Column range with [left-inclusive, right-exclusive)
@@ -27,17 +32,37 @@
 ---@class LineContext
 ---@field row WindowRow
 ---@field line string
+---@field line_cliped string
 ---@field col_bias WindowCol Bias column of the left clipped line
+---@field off_bias WindowCol Bias cell column of the left clipped blank cells for 'virtualedit' is enabled
 
+-- The Cursor and LineContext under WindowContext:
+-- ```
+--                  | virt         |
+-- | col_bias       |        | off |
+-- 1****************|========~~~~~~$~~|
+-- | win_offset     | win_width       |
+--
+--       | off                     |
+-- 2*****|~~~~~~~~~~|~~~~~~~~~~~~~~$~~|
+--       | off_bias | win_width       |
+-- ```
+-- '1' : line 1 with long line string
+-- '2' : line 2 with short line string
+-- '*' : line string hidded to window left
+-- '=' : line string displayed on window
+-- '~' : blank cells with any text after line string
+-- '$' : cursor with 'virtualedit' enabled
+--
 ---@class WindowContext
 ---@field win_handle integer
 ---@field buf_handle integer
----@field cursor CursorPos
+---@field cursor Cursor
 ---@field line_range LineRange
 ---@field column_range ColumnRange Left-column for top-line and right-column for bottom-line
 ---@field win_width WindowCell Window cell width excluding fold, sign and number columns
----@field col_offset WindowCell First cell column displayed (also is the cell number hidden to window left)
----@field col_first WindowCell Cursor cell column relative to the first cell column displayed
+---@field win_offset WindowCell First cell column displayed at window (also is the cell number hidden to window left)
+---@field virtualedit boolean The 'virtualedit' is enabled or not
 
 local M = {}
 local api = vim.api
@@ -54,8 +79,8 @@ function M.col2extmark(col)
   return col
 end
 
--- Convert CursorPos to extmark position
----@param pos CursorPos
+-- Convert Cursor to extmark position
+---@param pos Cursor
 function M.pos2extmark(pos)
   return pos.row - 1, pos.col
 end
@@ -81,14 +106,14 @@ function M.cell2char(line, cell)
     return 0
   end
 
-  local line_width = vim.fn.strdisplaywidth(line)
+  local line_cells = vim.fn.strdisplaywidth(line)
   local line_chars = vim.fn.strchars(line)
   -- No multi-byte character
-  if line_width == line_chars then
+  if line_cells == line_chars then
     return cell
   end
   -- Line is shorter than cell, all line should include
-  if line_width <= cell then
+  if line_cells <= cell then
     return line_chars
   end
 
@@ -106,7 +131,16 @@ function M.cell2char(line, cell)
     i = i + 1
     w = w + vim.fn.strdisplaywidth(lst[i])
   until w >= cell
-  return i
+  -- If w < cell, that is the i-th multi-byte character is after the cell
+  return w == cell and i or i - 1
+end
+
+-- Report virtualedit is enabled or not
+---@return boolean
+local function is_virtualedit_enabled(win_handle)
+  local ve = vim.wo[win_handle].virtualedit
+  local mode = vim.fn.mode()
+  return (ve == 'all') or (ve == 'insert' and mode == 'i') or (ve == 'block' and mode == '\22')
 end
 
 -- Get information about the window and the cursor
@@ -116,20 +150,25 @@ end
 local function window_context(win_handle, buf_handle)
   local win_info = vim.fn.getwininfo(win_handle)[1]
   local win_view = api.nvim_win_call(win_handle, vim.fn.winsaveview)
-  local cursor_pos = api.nvim_win_get_cursor(win_handle)
-  local cursor = { row = cursor_pos[1], col = cursor_pos[2] }
+  local cursor_pos = vim.fn.getcurpos(win_handle)
+  ---@type Cursor
+  local cursor = {
+    row = cursor_pos[2],
+    col = cursor_pos[3] - 1,
+    off = cursor_pos[4],
+    virt = nil,
+  }
+  local cursor_line = api.nvim_buf_get_lines(buf_handle, cursor.row - 1, cursor.row, false)[1]
+  cursor.virt = vim.fn.strdisplaywidth(cursor_line:sub(1, cursor.col)) + cursor.off - win_view.leftcol
 
   local bottom_line = api.nvim_buf_get_lines(buf_handle, win_info.botline - 1, win_info.botline, false)[1]
   local right_column = string.len(bottom_line)
 
   local win_width = nil
   if not vim.wo.wrap then
-    --number of columns occupied by any	'foldcolumn', 'signcolumn' and line number in front of the text
+    -- Number of columns occupied by any 'foldcolumn', 'signcolumn' and line number in front of the text
     win_width = win_info.width - win_info.textoff
   end
-
-  local cursor_line = api.nvim_buf_get_lines(buf_handle, cursor.row - 1, cursor.row, false)[1]
-  local col_first = vim.fn.strdisplaywidth(cursor_line:sub(1, cursor.col)) - win_view.leftcol
 
   return {
     win_handle = win_handle,
@@ -138,8 +177,8 @@ local function window_context(win_handle, buf_handle)
     line_range = { win_info.topline, win_info.botline },
     column_range = { 0, right_column },
     win_width = win_width,
-    col_offset = win_view.leftcol,
-    col_first = col_first,
+    win_offset = win_view.leftcol,
+    virtualedit = is_virtualedit_enabled(win_handle),
   }
 end
 
@@ -193,7 +232,9 @@ function M.get_lines_context(win_ctx)
     local line_ctx = {
       row = lnr,
       line = '',
+      line_cliped = '',
       col_bias = 0,
+      off_bias = 0,
     }
     if fold_end == -1 then
       line_ctx.line = api.nvim_buf_get_lines(win_ctx.buf_handle, lnr - 1, lnr, false)[1]
@@ -234,12 +275,13 @@ function M.clip_window_context(win_ctx, opts)
 
   local row = win_ctx.cursor.row
   local line = api.nvim_buf_get_lines(win_ctx.buf_handle, row - 1, row, false)[1]
+  local line_len = string.len(line)
 
   if opts.current_line_only then
     win_ctx.line_range[1] = row
     win_ctx.line_range[2] = row
     win_ctx.column_range[1] = 0
-    win_ctx.column_range[2] = string.len(line)
+    win_ctx.column_range[2] = line_len
   end
 
   if opts.direction == hint.HintDirection.BEFORE_CURSOR then
@@ -247,7 +289,7 @@ function M.clip_window_context(win_ctx, opts)
     win_ctx.column_range[2] = win_ctx.cursor.col
 
     -- For non-empty lines we have to increment it so we include the cursor
-    if #line > 0 then
+    if win_ctx.cursor.col + 1 <= line_len then
       win_ctx.column_range[2] = win_ctx.cursor.col + 1
     end
   elseif opts.direction == hint.HintDirection.AFTER_CURSOR then
@@ -264,31 +306,39 @@ function M.clip_line_context(win_ctx, line_ctx, opts)
   local hint = require('hop.hint')
 
   ---@type WindowCell
-  local end_cell = vim.fn.strdisplaywidth(line_ctx.line)
+  local line_cells = vim.fn.strdisplaywidth(line_ctx.line)
+  local end_cell = line_cells
   if win_ctx.win_width ~= nil then
-    end_cell = win_ctx.col_offset + win_ctx.win_width
+    end_cell = win_ctx.win_offset + win_ctx.win_width
   end
 
-  -- Handle shifted_line with cell2char for multiple-bytes chars
+  -- Handle cliped line with cell2char for multiple-bytes chars
   ---@type WindowChar
-  local left_idx = M.cell2char(line_ctx.line, win_ctx.col_offset)
+  local left_idx = M.cell2char(line_ctx.line, win_ctx.win_offset)
   ---@type WindowChar
   local right_idx = M.cell2char(line_ctx.line, end_cell)
-  local shifted_line = vim.fn.strcharpart(line_ctx.line, left_idx, right_idx - left_idx)
+  local line_cliped = vim.fn.strcharpart(line_ctx.line, left_idx, right_idx - left_idx)
   ---@type WindowCol
   local col_bias = vim.fn.byteidx(line_ctx.line, left_idx)
 
   if line_ctx.row == win_ctx.cursor.row then
     if opts.direction == hint.HintDirection.AFTER_CURSOR then
-      shifted_line = shifted_line:sub(1 + win_ctx.cursor.col - col_bias)
+      line_cliped = line_cliped:sub(1 + win_ctx.cursor.col - col_bias)
       col_bias = win_ctx.cursor.col
     elseif opts.direction == hint.HintDirection.BEFORE_CURSOR then
-      shifted_line = shifted_line:sub(1, 1 + win_ctx.cursor.col - col_bias)
+      line_cliped = line_cliped:sub(1, 1 + win_ctx.cursor.col - col_bias)
     end
   end
 
-  line_ctx.line = shifted_line
+  ---@type WindowCol
+  local off_bias = 0
+  if win_ctx.win_offset > line_cells then
+    off_bias = win_ctx.win_offset - line_cells
+  end
+
+  line_ctx.line_cliped = line_cliped
   line_ctx.col_bias = col_bias
+  line_ctx.off_bias = off_bias
 end
 
 return M

--- a/tests/hop/mappings_zh_spec.lua
+++ b/tests/hop/mappings_zh_spec.lua
@@ -32,8 +32,9 @@ describe('Hop with match mappings:', function()
     end)
   end)
 
-  it('hint_vertical,', function()
+  it('hint_vertical', function()
     vim.o.wrap = false
+    vim.wo[0].virtualedit = 'none'
     vim.api.nvim_win_set_cursor(0, { 1, 65 })
     local col = vim.fn.wincol()
 

--- a/tests/hop/virtualedit_spec.lua
+++ b/tests/hop/virtualedit_spec.lua
@@ -1,0 +1,52 @@
+local hop = require('hop')
+local eq = assert.are.same
+local api = vim.api
+local hop_helpers = require('hop_helpers')
+
+local override_keyseq = hop_helpers.override_keyseq
+
+describe('Hop with virtualedit enabled:', function()
+  before_each(function()
+    vim.cmd.view('tests/tst_virtualedit.txt')
+    hop.setup({ match_mappings = { 'zh_sc' } })
+
+    vim.o.wrap = false
+    vim.wo[0].virtualedit = 'all'
+  end)
+
+  it('hint_lines', function()
+    vim.api.nvim_win_set_cursor(0, { 1, 20 })
+
+    vim.cmd.normal({ args = { '8zl' }, bang = true })
+    vim.cmd.normal({ args = { 'lh' }, bang = true })
+
+    override_keyseq({ 'r' }, hop.hint_lines)
+    local curpos = vim.fn.getcurpos(0)
+    eq(12, curpos[2])
+    eq(5, curpos[3])
+    eq(4, curpos[4])
+  end)
+
+  it('hint_vertical', function()
+    vim.api.nvim_win_set_cursor(0, { 1, 20 })
+    local col = vim.fn.wincol()
+
+    override_keyseq({ 'h' }, hop.hint_vertical)
+    local curpos = vim.fn.getcurpos(0)
+    eq(6, curpos[2])
+    eq(21, curpos[3])
+    eq(4, curpos[4])
+    eq(col, vim.fn.wincol())
+
+    vim.cmd.normal({ args = { '8zl' }, bang = true })
+    vim.cmd.normal({ args = { 'lh' }, bang = true })
+    col = col - 8
+
+    override_keyseq({ 'l' }, hop.hint_vertical)
+    curpos = vim.fn.getcurpos(0)
+    eq(10, curpos[2])
+    eq(21, curpos[3])
+    eq(4, curpos[4])
+    eq(col, vim.fn.wincol())
+  end)
+end)

--- a/tests/hop/window_spec.lua
+++ b/tests/hop/window_spec.lua
@@ -9,9 +9,13 @@ describe('Hop window:', function()
     local idx = hop_window.cell2char(line, cell)
     eq('d测试ABCD', vim.fn.strcharpart(line, idx))
 
+    cell = 6
+    idx = hop_window.cell2char(line, cell)
+    eq('试ABCD', vim.fn.strcharpart(line, idx))
+
     cell = 7
     idx = hop_window.cell2char(line, cell)
-    eq('ABCD', vim.fn.strcharpart(line, idx))
+    eq('试ABCD', vim.fn.strcharpart(line, idx))
 
     cell = 8
     idx = hop_window.cell2char(line, cell)

--- a/tests/tst_virtualedit.txt
+++ b/tests/tst_virtualedit.txt
@@ -1,0 +1,14 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+start
+
+abcd
+abcd测试
+abcd测试abcd测试
+abcd测试abcd测试ABCD测试
+abcd测试abcd测试ABCD测试ABCD测试
+abcd测试abcd测试ABCD测试
+abcd测试abcd测试
+abcd测试
+abcd
+
+end


### PR DESCRIPTION
This PR allows hop to jump to anywhere you want with `virtualedit` used, even there is a blank cell like the picture showed below.
So any hop-regex/extension can supports `virtualedit` via only provide extra `Cursor.off` and `Cursor.virt`.
Currently `hint_vertical` and `hint_lines` can jump to blank cells when `virutaledit = insert/block/all`.

![ve](https://github.com/smoka7/hop.nvim/assets/17680752/364079fd-6457-4d9a-aa8d-c9ae4899d988)