### PR TITLE
feat: allow users to supply custom distance functions #66

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -720,6 +720,16 @@ below.
     
     Defaults:~
         `x_bias = 10`
+            
+    `distance_method`                                  *hop-config-distance_method*
+    This Determines the method which hops uses to evaluate the distance between 
+    jump target and the cursor.
+
+    We currently provide two `manh_distance` and `readwise_distance`
+     distance methods in `hint` module.
+
+    Defaults:~
+        `distance_method = require('hop.hint').manh_distance`
 
 `teasing`                                                     *hop-config-teasing*
     Boolean value stating whether Hop should tease you when you do something

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -10,6 +10,7 @@ M.quit_key = '<Esc>'
 M.perm_method = require('hop.perm').TrieBacktrackFilling
 M.reverse_distribution = false
 M.x_bias = 10
+M.distance_method = hint.manh_distance
 M.teasing = true
 M.virtual_cursor = false
 M.jump_on_sole_occurrence = true

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -49,6 +49,15 @@ M.HintPriority = {
   CURSOR = 65535,
 }
 
+-- Manhattan distance with column and row, weighted on x so that results are more packed on y.
+---@param a CursorPos
+---@param b CursorPos
+---@param x_bias number
+---@return number
+function M.manh_distance(a, b, x_bias)
+  return (x_bias * math.abs(b.row - a.row)) + math.abs(b.col - a.col)
+end
+
 -- Reduce a hint.
 -- This function will remove hints not starting with the input key and will reduce the other ones
 -- with one level.

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -58,6 +58,16 @@ function M.manh_distance(a, b, x_bias)
   return (x_bias * math.abs(b.row - a.row)) + math.abs(b.col - a.col)
 end
 
+--- Distance method that prioritises hints based on the
+--- left to right reading distance
+---@param a CursorPos Cursor Position
+---@param b CursorPos Jump target position
+---@param x_bias number
+---@return number 
+function M.readwise_distance(a, b, x_bias)
+  return (100 * math.abs(b.row - a.row)) + (b.col - a.col)
+end
+
 -- Reduce a hint.
 -- This function will remove hints not starting with the input key and will reduce the other ones
 -- with one level.

--- a/lua/hop/jump_target.lua
+++ b/lua/hop/jump_target.lua
@@ -32,15 +32,6 @@ local window = require('hop.window')
 ---@class JumpTargetModule
 local M = {}
 
--- Manhattan distance with column and row, weighted on x so that results are more packed on y.
----@param a CursorPos
----@param b CursorPos
----@param x_bias number
----@return number
-local function manh_dist(a, b, x_bias)
-  return (x_bias * math.abs(b.row - a.row)) + math.abs(b.col - a.col)
-end
-
 -- Create jump targets within line
 ---@param jump_ctx JumpContext
 ---@param opts Options
@@ -113,10 +104,9 @@ local function create_line_indirect_jump_targets(jump_ctx, locations, opts)
   local win_bias = math.abs(vim.api.nvim_get_current_win() - jump_ctx.win_ctx.win_handle) * 1000
   for _, jump_target in pairs(line_jump_targets) do
     locations.jump_targets[#locations.jump_targets + 1] = jump_target
-
     locations.indirect_jump_targets[#locations.indirect_jump_targets + 1] = {
       index = #locations.jump_targets,
-      score = manh_dist(jump_ctx.win_ctx.cursor, jump_target.cursor, opts.x_bias) + win_bias,
+      score = opts.distance_method(jump_ctx.win_ctx.cursor, jump_target.cursor, opts.x_bias) + win_bias,
     }
   end
 end


### PR DESCRIPTION
I explored different options, but ultimately it seems sorting the distance is the only way to get consistent read-wise ordering. The custom function doesn't take xbias, since users can supply that themselves, and win_bias is borrowed from elsewhere, since window params are not ( yet? ) provided to the custom function.

Tested with this config:


```
local hop = require('hop')

local readwise_distance = function(a, b)
        return (100 * math.abs(b.row - a.row)) + (b.col - a.col);
end

hop.setup{keys = 'asdfjklqweruiopzxmtgbyhn', x_bias = 10,
          custom_distance_fn = readwise_distance }

local directions = require('hop.hint').HintDirection
vim.keymap.set({'o', 'n'}, 'f', function()
  hop.hint_char1({ direction = directions.AFTER_CURSOR, current_line_only = false})
end, {remap = true})
```


```
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab
cccccccccccccbccccccccccccccccccccccc
```


Without the custom function, if you go above the "b" on the second line and hit "fb", the b on the second line is designated character a.