### PR TITLE
feat: optional timeout on pattern mode

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -851,6 +851,13 @@ below.
     Defaults:~
         `multi_windows = false`
 
+`timeout`                                                     *hop-config-timeout*
+    Starts a timer after the first valid key in pattern mode which submits the
+    query after `timeout` milliseconds if no other keys are pressed.
+
+    Defaults:~
+        `timeout = nil`
+
 `excluded_filetypes`
     Skip hinting windows with the excluded filetypes. Those windows to check
     filetypes are collected only when you enable `multi_windows` or execute

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -26,5 +26,6 @@ M.hint_type = hint.HintType.OVERLAY ---@type HintType
 M.excluded_filetypes = {}
 M.match_mappings = {}
 M.extensions = { 'hop-yank', 'hop-treesitter' }
+M.timeout = nil
 
 return M


### PR DESCRIPTION
I really liked Emacs' [avy-goto-char-timer](https://github.com/abo-abo/avy?tab=readme-ov-file#avy-goto-char-timer), and this seemed like the best project to add this feature to in the Neovim space.

Basically, it's the regular pattern search, but with an automatic enter press after a certain time of no typing. Here's a little demo:

https://github.com/smoka7/hop.nvim/assets/56356662/85d11065-f8e0-49de-bb33-3aafbfbfb1f9

I had to change the `getcharstr` call to always return something each cycle instead of wait for a key to be pressed, which meant a few more conditionals, but I think it should be fine.