### PR TITLE
feat: add windows-list to allow custom window candidates

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -862,15 +862,12 @@ below.
         `multi_windows = false`
 
 `windows_list`                                           *hop-config-windows_list*
-    List-table of windows to jump to. When `multi_windows` is enabled, only
-    the windows on the list will be hint. You can write a function to exclude
-    the windows you don't want to jump to.
+    A function returns a list-table of windows to jump to. When `multi_windows`
+    is enabled, only the windows on the list will be hint.
 
-    Defaults:~ >lua
+    Defaults:~ >
         windows_list = function ()
-          return vim.tbl_filter(function (w)
-            return vim.api.nvim_win_get_config(w).focusable
-          end, vim.api.nvim_tabpage_list_wins(0))
+          return vim.api.nvim_tabpage_list_wins(0)
         end
 <
 `excluded_filetypes`

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -841,16 +841,28 @@ below.
         `extensions = nil`
 
 `multi_windows`                                         *hop-config-multi_windows*
-    Enable cross-windows support and hint all the currently visible windows.
-    This behavior allows you to jump around any position in any buffer
-    currently visible in a window. Although a powerful a feature, remember
-    that enabling this will also generate many more sequence combinations, so
-    you could get deeper sequences to type (most of the time it should be good
-    if you have enough keys in |hop-config-keys|).
+    Enable cross-windows support and hint all the windows listed in
+    `windows_list`. This behavior allows you to jump around any position in any
+    buffer currently visible in an editor. Although a powerful a feature,
+    remember that enabling this will also generate many more sequence
+    combinations, so you could get deeper sequences to type (most of the time
+    it should be good if you have enough keys in |hop-config-keys|).
 
     Defaults:~
         `multi_windows = false`
 
+`windows_list`                                           *hop-config-windows_list*
+    List-table of windows to jump to. When `multi_windows` is enabled, only
+    the windows on the list will be hint. You can write a function to exclude
+    the windows you don't want to jump to.
+
+    Defaults:~ >lua
+        windows_list = function ()
+          return vim.tbl_filter(function (w)
+            return vim.api.nvim_win_get_config(w).focusable
+          end, vim.api.nvim_tabpage_list_wins(0))
+        end
+<
 `excluded_filetypes`
     Skip hinting windows with the excluded filetypes. Those windows to check
     filetypes are collected only when you enable `multi_windows` or execute

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -19,6 +19,11 @@ M.current_line_only = false
 M.dim_unmatched = true
 M.uppercase_labels = false
 M.multi_windows = false
+M.windows_list = function ()
+  return vim.tbl_filter(function (w)
+    return vim.api.nvim_win_get_config(w).focusable
+  end, vim.api.nvim_tabpage_list_wins(0))
+end
 M.ignore_injections = false
 M.hint_position = hint.HintPosition.BEGIN ---@type HintPosition
 M.hint_offset = 0 ---@type WindowCell

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -21,9 +21,7 @@ M.dim_unmatched = true
 M.uppercase_labels = false
 M.multi_windows = false
 M.windows_list = function ()
-  return vim.tbl_filter(function (w)
-    return vim.api.nvim_win_get_config(w).focusable
-  end, vim.api.nvim_tabpage_list_wins(0))
+  return vim.api.nvim_tabpage_list_wins(0)
 end
 M.ignore_injections = false
 M.hint_position = hint.HintPosition.BEGIN ---@type HintPosition

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -161,10 +161,9 @@ function M.get_windows_context(opts)
   end
 
   -- Get the context for all the windows in current tab
-  for _, w in ipairs(api.nvim_tabpage_list_wins(0)) do
+  for _, w in ipairs(opts.windows_list()) do
     local valid_win = api.nvim_win_is_valid(w)
-    local not_relative = api.nvim_win_get_config(w).relative == ''
-    if valid_win and not_relative and w ~= cur_hwin then
+    if valid_win and w ~= cur_hwin then
       local b = api.nvim_win_get_buf(w)
 
       -- Skips current window and excluded filetypes

--- a/lua/hop/window.lua
+++ b/lua/hop/window.lua
@@ -163,7 +163,8 @@ function M.get_windows_context(opts)
   -- Get the context for all the windows in current tab
   for _, w in ipairs(opts.windows_list()) do
     local valid_win = api.nvim_win_is_valid(w)
-    if valid_win and w ~= cur_hwin then
+    local focusable_win = vim.api.nvim_win_get_config(w).focusable
+    if valid_win and focusable_win and w ~= cur_hwin then
       local b = api.nvim_win_get_buf(w)
 
       -- Skips current window and excluded filetypes


### PR DESCRIPTION
In `multi-windows` mode, there will be some windows you don't want to jump to. For example, float windows based plugins like [NeoZoom.lua](https://github.com/nyngwang/NeoZoom.lua) or [detour.nvim](https://github.com/carbon-steel/detour.nvim).

A `windows-list` option is added to supply these scenarios. Its default value is much like the original code: all windows except unfocusable windows. It's allowing user jump between float windows, but not the windows cannot be focus to, which are used a lot by [incline.nvim](https://github.com/b0o/incline.nvim).