### PR TITLE
fix: virtual cursor hl overwhelme by search hl

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -874,6 +874,15 @@ below.
     Defaults:~
         `dim_unmatched = true`
 
+`hl_mode`                                                     *hop-config-hl_mode*
+    Highlight mode of the hint chars. Set this option to `combine` will
+    preserve the background colors of original chars. Set this option to
+    `replace` will remove the background colors of original chars. It's useful
+    when the hint chars is not clear on search highlights.
+
+    Defaults:~
+        `dim_unmatched = "combine"`
+
 `direction`                                                 *hop-config-direction*
     Direction in which to hint. See |hop.hint.HintDirection| for further
     details.

--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -881,7 +881,7 @@ below.
     when the hint chars is not clear on search highlights.
 
     Defaults:~
-        `dim_unmatched = "combine"`
+        `hl_mode = "combine"`
 
 `direction`                                                 *hop-config-direction*
     Direction in which to hint. See |hop.hint.HintDirection| for further

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -18,6 +18,7 @@ M.case_insensitive = true
 M.create_hl_autocmd = true
 M.current_line_only = false
 M.dim_unmatched = true
+M.hl_mode = "combine"
 M.uppercase_labels = false
 M.multi_windows = false
 M.windows_list = function ()

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -202,7 +202,7 @@ function M.set_hint_extmarks(hl_ns, hints, opts)
     api.nvim_buf_set_extmark(hint.jump_target.buffer, hl_ns, row, col, {
       virt_text = virt_text,
       virt_text_pos = opts.hint_type,
-      hl_mode = 'combine',
+      hl_mode = opts.hl_mode,
       priority = M.HintPriority.HINT,
     })
   end


### PR DESCRIPTION
Currently, hop uses `combine` hl mode on virtual text. If the search highlight is bright color, the virtual text became hard to recognize. The fix change the hl mode to `replace`.

Another option is to dim the search highlight together with original text.

Before hop:
![圖片](https://github.com/smoka7/hop.nvim/assets/22725367/c4a3ae87-254f-4e01-b7f7-dcacb585327c)
After hop origin:
![圖片](https://github.com/smoka7/hop.nvim/assets/22725367/ec6f336d-ff49-4458-948b-f3cc5d54d3bf)
After hop fix:
![圖片](https://github.com/smoka7/hop.nvim/assets/22725367/0dd04970-5ce0-4dc8-b578-326ec86d2fcc)
