### PR TITLE
feat: Go to previous hint state on repeat_key

### DIFF
--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -7,6 +7,7 @@ local hint = require('hop.hint')
 
 M.keys = 'asdghklqwertyuiopzxcvbnmfj'
 M.quit_key = '<Esc>'
+M.repeat_key = '<BS>'
 M.perm_method = require('hop.perm').TrieBacktrackFilling
 M.reverse_distribution = false
 M.x_bias = 10

--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -14,6 +14,7 @@ local api = vim.api
 ---@field dim_ns integer
 ---@field preview_ns integer
 ---@field diag_ns table
+---@field history table[]
 
 local M = {}
 
@@ -176,6 +177,9 @@ function M.create_hint_state(opts)
 
   -- Backup namespaces of diagnostic
   hint_state.diag_ns = vim.diagnostic.get_namespaces()
+
+  -- Initialize history
+  hint_state.history = {}
 
   return hint_state
 end


### PR DESCRIPTION
Added ``repeat_key`` to go back to previous hint state. Previously, if a mistake was made when initially pressing a ``key``, undoing the mistake would require running the command again (e.g. ``HopWord``). Now, on ``repeat_key`` you can go back a step.