### PR TITLE
Add motion_forcing to Hop. #65

### DIFF
--- a/doc/hop.txt
+++ b/doc/hop.txt
@@ -933,6 +933,21 @@ below.
     Defaults:~
         `current_line_only = false`
 
+`forced_motion`                                 *hop-config-forced_motion*
+    When applying Hop commands in operator mode, control the type of motion
+    that Hop should emulate. The Neovim docs for |forced-motion| explain the
+    options. For example, `forced_motion = "V"` will turn the motion into a
+    linewise motion while `forced_motion = "v"` will turn the motion into a
+    charwise motion. this is very useful with jumps that target lines such as
+    |hop.hint_vertical| or |hop.hint_lines| so that you can make them
+    linewise. If `nil`, the motion will try force the motion to be charwise if
+    the direction is after the cursor and blockwise if the direction is before
+    the cursor. This lines up with how Neovim normally handles the f/t/F/T
+    commands.
+
+    Defaults:~
+        `forced_motion = nil`
+
 `uppercase_labels`                                   *hop-config-uppercase_labels*
     Display labels as uppercase. This option only affects the displayed
     labels; you still select them by typing the keys on your keyboard.

--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -1,6 +1,7 @@
 ---@class Options
 ---@field direction HintDirection
 ---@field loaded_mappings any
+---@field forced_motion string?
 local M = {}
 
 local hint = require('hop.hint')

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -223,9 +223,17 @@ function M.move_cursor_to(jt, opts)
   local hint = require('hop.hint')
   local jump_target = require('hop.jump_target')
 
-  -- If it is pending for operator shift pos.col to the right by 1
-  if api.nvim_get_mode().mode == 'no' and opts.direction ~= hint.HintDirection.BEFORE_CURSOR then
-    jt.cursor.col = jt.cursor.col + 1
+  -- If it is pending for operator, make sure we include the entire selection
+  if api.nvim_get_mode().mode == 'no' then
+    if opts.forced_motion then
+      vim.cmd('normal! ' .. opts.forced_motion)
+    elseif opts.direction == hint.HintDirection.AFTER_CURSOR then
+      -- This lines up with how the f and t motions work
+      vim.cmd('normal! v')
+    elseif opts.direction == hint.HintDirection.BEFORE_CURSOR then
+      -- This lines up with how the F and T motions work
+      vim.cmd('normal! <C-V>')
+    end
   end
 
   jump_target.move_jump_target(jt, 0, opts.hint_offset)


### PR DESCRIPTION
This gives users an easy way to customize how motions work with operators. You can force the motion to act linewise, charwise, or blockwise. The default tries to match how Neovim's handles the f/t/F/T operators.