### PR TITLE
fix: escape special chars before putting them into regex charclass (#92)

### DIFF
--- a/lua/hop/mappings.lua
+++ b/lua/hop/mappings.lua
@@ -18,7 +18,7 @@ function M.checkout(pat, opts)
     end
 
     if dict_char_pat ~= '' then
-      dict_pat = dict_pat .. '[' .. dict_char_pat .. ']'
+      dict_pat = dict_pat .. '[' .. vim.fn.escape(dict_char_pat, ']^-\\') .. ']'
     end
   end
 


### PR DESCRIPTION
This escapes `]`, `^`, `-`, and `\` (https://regexper.cn/charclass.html).

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/8d9e4842-f55e-452b-8698-8f9a17d533a6)|![image](https://github.com/user-attachments/assets/f9bbc483-ed7a-4d84-b55e-eab38014c9e5)|

