### PR TITLE
Fix dimming bug - Make dimming apply to whole window including last line

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -96,11 +96,11 @@ end
 --- verify that column value is always smaller than line length
 ---@param wctx WindowContext
 local function sanitize_cols(wctx)
-  local start_line = api.nvim_buf_get_lines(wctx.buf_handle, wctx.line_range[1], wctx.line_range[1] + 1, false)
+  local start_line = api.nvim_buf_get_lines(wctx.buf_handle, wctx.line_range[1] - 1, wctx.line_range[1], false)[1]
   if #start_line < wctx.column_range[1] then
     wctx.column_range[1] = #start_line
   end
-  local end_line = api.nvim_buf_get_lines(wctx.buf_handle, wctx.line_range[2], wctx.line_range[2] + 1, false)
+  local end_line = api.nvim_buf_get_lines(wctx.buf_handle, wctx.line_range[2] - 1, wctx.line_range[2], false)[1]
   if #end_line < wctx.column_range[2] then
     wctx.column_range[2] = #end_line
   end


### PR DESCRIPTION
There were two typo-induced bugs in `sanitize_cols`, so the bottom line of dimmed windows often wouldn't be dimmed.

`vim.api.nvim_buf_get_lines` returns a list, not the line itself

The line number parameters to `vim.api.nvim_buf_get_lines` are 0-indexed, but `LineRange` numbers are 1-indexed