### PR TITLE
Fix #85 #65 : Make motion inclusive by default, with support for toggling

### DIFF
--- a/lua/hop/defaults.lua
+++ b/lua/hop/defaults.lua
@@ -1,6 +1,9 @@
+---@alias VisualMode '"v"' | '"V"' | '"<C-v>"' the mode to enter if operator pending
+
 ---@class Options
 ---@field direction HintDirection
 ---@field loaded_mappings any
+---@field visual_mode? VisualMode # should be V for linewise operators (hint_lines), unset otherwise
 local M = {}
 
 local hint = require('hop.hint')

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -235,7 +235,22 @@ function M.move_cursor_to(jt, opts)
   api.nvim_set_current_win(jt.window)
   --local cursor = api.nvim_win_get_cursor(0)
   --api.nvim_buf_set_mark(jt.buffer, "'", cursor[1], cursor[2], {})
+
+  -- we must check the mode before the normal! m' line, which can change it
+  local mode = vim.fn.mode(true)
+
   vim.cmd("normal! m'")
+
+  -- only specialize for operator pending mode if jumping to the same buffer
+  if jt.buffer == vim.fn.bufnr('%') then
+    -- If operator pending, first check if a visual mode should be set
+    if mode == 'no' then
+      if opts.visual_mode ~= nil then
+        vim.cmd([[noautocmd normal! ]] .. opts.visual_mode)
+      end
+    end
+  end
+
   api.nvim_win_set_cursor(jt.window, { jt.cursor.row, jt.cursor.col })
 end
 
@@ -465,10 +480,7 @@ function M.hint_lines(opts)
   local jump_regex = require('hop.jump_regex')
 
   opts = override_opts(opts)
-
-  if vim.fn.mode(true) == 'no' then
-    vim.cmd[[noautocmd normal! V]]
-  end
+  opts.visual_mode = opts.visual_mode or 'V'
 
   M.hint_with_regex(jump_regex.by_line_start(), opts)
 end
@@ -477,11 +489,9 @@ end
 function M.hint_vertical(opts)
   local jump_regex = require('hop.jump_regex')
 
-  if vim.fn.mode(true) == 'no' then
-    vim.cmd[[noautocmd normal! V]]
-  end
-
   opts = override_opts(opts)
+  opts.visual_mode = opts.visual_mode or 'V'
+
   M.hint_with_regex(jump_regex.regex_by_vertical(), opts)
 end
 
@@ -489,11 +499,9 @@ end
 function M.hint_lines_skip_whitespace(opts)
   local jump_regex = require('hop.jump_regex')
 
-  if vim.fn.mode(true) == 'no' then
-    vim.cmd[[noautocmd normal! V]]
-  end
-
   opts = override_opts(opts)
+  opts.visual_mode = opts.visual_mode or 'V'
+
   M.hint_with_regex(jump_regex.regex_by_line_start_skip_whitespace(), opts)
 end
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -465,12 +465,21 @@ function M.hint_lines(opts)
   local jump_regex = require('hop.jump_regex')
 
   opts = override_opts(opts)
+
+  if vim.fn.mode(true) == 'no' then
+    vim.cmd[[noautocmd normal! V]]
+  end
+
   M.hint_with_regex(jump_regex.by_line_start(), opts)
 end
 
 ---@param opts Options
 function M.hint_vertical(opts)
   local jump_regex = require('hop.jump_regex')
+
+  if vim.fn.mode(true) == 'no' then
+    vim.cmd[[noautocmd normal! V]]
+  end
 
   opts = override_opts(opts)
   M.hint_with_regex(jump_regex.regex_by_vertical(), opts)
@@ -479,6 +488,10 @@ end
 ---@param opts Options
 function M.hint_lines_skip_whitespace(opts)
   local jump_regex = require('hop.jump_regex')
+
+  if vim.fn.mode(true) == 'no' then
+    vim.cmd[[noautocmd normal! V]]
+  end
 
   opts = override_opts(opts)
   M.hint_with_regex(jump_regex.regex_by_line_start_skip_whitespace(), opts)


### PR DESCRIPTION
`:help forced-motion` 

I think it would be much more intuitive if hop motions were truly inclusive by default

They were already trying to be, but as #85 points out, it didn't work consistently

I've fixed the behaviour so that hop is always inclusive by default and always consistent, and just like most vim motions, I've also added support to toggle it to be exclusive by pressing `v` first in operator pending mode (before starting the hop motion, `:help o_v`)

With this small change, #85's author's snippet

```
require("hop").setup {}

vim.keymap.set({ "n", "v", "o" }, "f", function()
  vim.cmd "HopChar1CurrentLine"
end, { silent = true })

-- somefn(arg);
```

Does work exactly the same as the builtin `f`, try `df)`, `df;`, `dvf;`

And if using `HopChar1` instead of `CurrentLine`, then `dVf...` and `d<C-v>f...` also behave as you would expect according to all standard vim motions and `:help forced-motion`.