### PR TITLE
fix: make case_insensitive work even if smartcase is not set

### DIFF
--- a/lua/hop/jump_regex.lua
+++ b/lua/hop/jump_regex.lua
@@ -54,10 +54,8 @@ end
 ---@return Regex
 function M.regex_by_case_searching(pat, plain_search, opts)
   local pat_case = ''
-  if opts.case_insensitive then
-    if vim.o.smartcase and not starts_with_uppercase(pat) then
-      pat_case = '\\c'
-    end
+  if opts.case_insensitive and not (vim.o.smartcase and starts_with_uppercase(pat)) then
+    pat_case = '\\c'
   end
   local pat_mappings = mappings.checkout(pat, opts)
 


### PR DESCRIPTION
https://github.com/smoka7/hop.nvim/pull/76 changed the behavior of case_insensitive in the following way: now if case_insensitive is set it only works if ``smartcase`` is set and ``starts_with_uppercase(pat)`` is true.

This patch makes ``case_insensitive`` work even if ``smartcase`` is not set (``smartcase`` [is not set by default](
https://neovim.io/doc/user/options.html#'smartcase')). Otherwise ``case_insensitive = true`` doesn't work in neovim with default settings and requires setting ``smartcase = true`` just to make ``case_insensitive = true`` work.