### PR TITLE
fix: clear cmdline area based on cmdheight

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -176,7 +176,7 @@ function M.get_input_pattern(prompt, maxchar, opts)
       end
     end
 
-    api.nvim_echo({}, false, {})
+    api.nvim_echo({ { string.rep('\n', vim.o.cmdheight) } }, false, {})
     vim.cmd.redraw()
     api.nvim_echo({ { prompt, 'Question' }, { pat } }, false, {})
 
@@ -210,7 +210,7 @@ function M.get_input_pattern(prompt, maxchar, opts)
       M.quit(hs)
     end
   end
-  api.nvim_echo({}, false, {})
+  api.nvim_echo({ { string.rep('\n', vim.o.cmdheight) } }, false, {})
   vim.cmd.redraw()
   return pat
 end


### PR DESCRIPTION
Fix #77. Emit `vim.api.nvim_echo` based on the height of the command line. The `vim.api.nvim_echo` did not append newline after the message. Therefore, the message should be newline ('\n') instead of empty.