### PR TITLE
Load match_mappings on demand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 # run tests located at «lua/tests/» (files named *_spec.lua)
 TESTS_INIT=tests/minimal_init.lua
 TESTS_DIR=tests/
+PROFILE_DIR=tests/profile/
 
-.PHONY: test
+.PHONY: test profile
 
 test:
 	nvim  --headless --noplugin -u ${TESTS_INIT} -c "PlenaryBustedDirectory ${TESTS_DIR} { minimal_init = '${TESTS_INIT}' }"
+
+profile:
+	@nvim --headless --noplugin -u  ${PROFILE_DIR}init.lua -V1 -l '${PROFILE_DIR}setup.lua'
+	@nvim --headless --noplugin -u  ${PROFILE_DIR}init.lua -V1 -l '${PROFILE_DIR}setup_mappings.lua'

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -498,15 +498,9 @@ function M.setup(opts)
   M.opts = setmetatable(opts or {}, { __index = require('hop.defaults') })
   M.initialized = true
 
-  -- Load dict of match mappings
+  -- Prepare dict of match mappings
   if #M.opts.match_mappings > 0 then
     M.opts.loaded_mappings = {}
-    for _, map in ipairs(M.opts.match_mappings) do
-      local val = require('hop.mappings.' .. map)
-      if val ~= nil then
-        M.opts.loaded_mappings[map] = val
-      end
-    end
   end
 
   -- Insert the highlights and register the autocommand if asked to.

--- a/lua/hop/mappings.lua
+++ b/lua/hop/mappings.lua
@@ -1,5 +1,23 @@
 local M = {}
 
+-- Load the table for an item in match-mappings, returns cache once loaded.
+---@param name string Name of the mapping
+---@param opts Options
+function get_mapping(name, opts)
+  if opts.loaded_mappings[name] then
+    return opts.loaded_mappings[name]
+  end
+
+  local ok, val = pcall(require, 'hop.mappings.' .. name)
+  if not ok then
+    vim.notify(string.format('Hop can’t load "%s" (in match_mappings)', name), vim.log.levels.ERROR)
+  end
+
+  opts.loaded_mappings[name] = val or {}
+
+  return opts.loaded_mappings[name]
+end
+
 -- Checkout match-mappings with key from each pattern character
 ---@param pat string Pattern to search inputed from user
 ---@param opts Options
@@ -11,7 +29,8 @@ function M.checkout(pat, opts)
     local dict_char_pat = ''
     -- checkout dict-char pattern from each mapping dict
     for _, v in ipairs(opts.match_mappings) do
-      local val = opts.loaded_mappings[v][char]
+      local mapping = get_mapping(v, opts)
+      local val = mapping[char]
       if val ~= nil then
         dict_char_pat = dict_char_pat .. val
       end

--- a/tests/lua/profile_helpers.lua
+++ b/tests/lua/profile_helpers.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+---@param name string
+---@param func function
+function M.timing(name, func)
+  local t_start = vim.uv.hrtime()
+  func()
+  local t_end = vim.uv.hrtime()
+  local diff = t_end - t_start
+
+  print(string.format("Time elapsed: %9s\t%s\n", diff, name))
+end
+
+return M

--- a/tests/profile/init.lua
+++ b/tests/profile/init.lua
@@ -1,0 +1,3 @@
+vim.opt.swapfile = false
+vim.opt.rtp:append('.')
+vim.opt.rtp:append('./tests')

--- a/tests/profile/setup.lua
+++ b/tests/profile/setup.lua
@@ -1,0 +1,11 @@
+local profile_helpers = require('profile_helpers')
+
+profile_helpers.timing('setup (default)', function()
+  local hop = require('hop')
+
+  hop.setup({
+    match_mappings = {},
+  })
+end)
+
+vim.cmd('quit!')

--- a/tests/profile/setup_mappings.lua
+++ b/tests/profile/setup_mappings.lua
@@ -1,0 +1,11 @@
+local profile_helpers = require('profile_helpers')
+
+profile_helpers.timing('setup match_mappings', function()
+  local hop = require('hop')
+
+  hop.setup({
+    match_mappings = { 'fa', 'zh', 'zh_sc', 'zh_tc' },
+  })
+end)
+
+vim.cmd('quit!')


### PR DESCRIPTION
## Problem
Using the option `match_mappings` can introduce small overhead during setup, for example the Chinese mapping table (`zh_tc`) has 40K in size, which takes extra 0.3ms on my machine.

This PR defer the mapping table loading to actually calling time (for example HopChar1).

## New: make profile

Also add a simple timing script, by running `make profile` we can observe the time elapsing of `hop.setup()` with or without `match_mappings`.

Currently this is only provided for manually evaluation, example screenshot:
<img width="586" height="566" alt="make-profile-output" src="https://github.com/user-attachments/assets/b123594f-159f-4055-a6ee-4f52857b1d02" />

## Change: guard loading error

And a small guard is added to the loading process, previously if we setup an non-exist mapping:

```lua
require'hop'.setup({
  match_mappings = { 'zh', 'FOO_exist' },
})
```

the setup will failed with exception (not found), this is also changed in the PR, now the setup silently pass, but will notify user when actually use it, as in screenshot:
<img width="717" height="350" alt="loading-error" src="https://github.com/user-attachments/assets/65bd0301-9890-41cc-934c-e8b1274276f3" />
