### PR TITLE
fix: better solution to clear cmdline area based on cmdheight

### DIFF
--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -210,8 +210,10 @@ function M.get_input_pattern(prompt, maxchar, opts)
       M.quit(hs)
     end
   end
-  api.nvim_echo({}, false, {})
-  vim.cmd.redraw()
+  vim.schedule(function()
+    api.nvim_echo({}, false, {})
+    vim.cmd.redraw()
+  end)
   return pat
 end
 

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -176,7 +176,7 @@ function M.get_input_pattern(prompt, maxchar, opts)
       end
     end
 
-    api.nvim_echo({ { string.rep('\n', vim.o.cmdheight) } }, false, {})
+    api.nvim_echo({}, false, {})
     vim.cmd.redraw()
     api.nvim_echo({ { prompt, 'Question' }, { pat } }, false, {})
 
@@ -210,7 +210,7 @@ function M.get_input_pattern(prompt, maxchar, opts)
       M.quit(hs)
     end
   end
-  api.nvim_echo({ { string.rep('\n', vim.o.cmdheight) } }, false, {})
+  api.nvim_echo({}, false, {})
   vim.cmd.redraw()
   return pat
 end


### PR DESCRIPTION
Reverts smoka7/hop.nvim#105. Based on discussion with @monkoose, the problem is Neovim does not execute redraw right after the command ends. The prompt generated by Hop still remain in the cmdline area for the cmdline height larger than 1. Therefore, we can utilize vim.schedule to force the redraw occurs after command is complete.