### PR TITLE
add right_align option to hint_type

### DIFF
--- a/lua/hop/hint.lua
+++ b/lua/hop/hint.lua
@@ -34,6 +34,7 @@ M.HintPosition = {
 M.HintType = {
   OVERLAY = 'overlay',
   INLINE = 'inline',
+  RIGHT_ALIGN = 'right_align'
 }
 
 ---@enum HintPriority

--- a/lua/hop/init.lua
+++ b/lua/hop/init.lua
@@ -17,7 +17,7 @@ local function check_opts(opts)
     return
   end
 
-  if vim.version.cmp({ 0, 10, 0 }, vim.version()) < 0 then
+  if vim.version.cmp({ 0, 10, 0 }, vim.version()) > 0 then
     local hint = require('hop.hint')
     opts.hint_type = hint.HintType.OVERLAY
   end
@@ -30,6 +30,13 @@ local function check_opts(opts)
   local mode = api.nvim_get_mode().mode
   if mode ~= 'n' and mode ~= 'nt' then
     opts.multi_windows = false
+  end
+
+	local caller = debug.getinfo(3).name
+	if caller ~= 'hint_lines' and caller ~= 'hint_lines_skip_whitespace' then
+    if opts.hint_type == 'right_align' then
+      vim.notify('Cannot use right_align with this action (' .. caller .. ')', vim.log.levels.WARN)
+    end
   end
 end
 


### PR DESCRIPTION
Added right_align as an option in the HintType enum to use with linewise hops (hint_lines and hint_lines_skip_whitespace)
Also added a warning in check_opts when used with other hops because it doesn't make sense

<img width="1004" height="772" alt="20260219_194655_screen" src="https://github.com/user-attachments/assets/d13d7388-4c60-4bc4-b4a8-71617e7ed6b0" />
